### PR TITLE
fix: pre-commit config: bump pycln to working version after PyYAML v5.X dependencies stopped working

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
         args: [--py37-plus]
 
   - repo: https://github.com/hadialqattan/pycln
-    rev: v1.2.5
+    rev: v2.4.0
     hooks:
       - id: pycln
         args: [--config=pyproject.toml]


### PR DESCRIPTION
The template's "devcontainer" wasn't working, with an obscure error about "AttributeError: cython_sources" during a pip install, in a "Called Process" - see https://github.com/microsoft/python-package-template/issues/151.

After some investigation it turned out that this was happening during the devContainer's `onCreateCommand`, which runs `pre-commit install-hooks`.

Searching for other projects with the same error showed that one typical solution is to upgrade to PyYAML 6.X, but as the version of PyYAML in this particular `pip install` is actually driven by the `from pycln==1.2.5` constraint, that's what needs to be bumped for this template to start working again.

Fixes https://github.com/microsoft/python-package-template/issues/151.