### PR TITLE
fix: Add module name to overgeneral-exceptions to suppress warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -310,6 +310,6 @@ deprecated-modules="optparse,tkinter.tix"
 
 [tool.pylint.'EXCEPTIONS']
 overgeneral-exceptions= [
-    "BaseException",
-    "Exception"
+    "builtin.BaseException",
+    "builtin.Exception"
 ]


### PR DESCRIPTION
`pylint` will deprecate exception names without a module name in the pyproject.toml configurations.

When running pylint, you now get the following UserWarning:
```
$ pylint src
pylint: Command line or configuration file:1: UserWarning: Specifying exception names in the overgeneral-exceptions option without module name is deprecated and support for it will be removed in pylint 3.0. Use fully qualified name (maybe 'builtins.BaseException' ?) instead.
```

This PR follows this recommendation before support is removed.